### PR TITLE
Put all talks on equal footing in Talks section

### DIFF
--- a/content/home/talks.md
+++ b/content/home/talks.md
@@ -15,9 +15,7 @@ subtitle = ""
  css_class = ""
 +++
 
-## IBS for General Practice — How to Approach, Help and Treat
-Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
-
+- IBS for General Practice — How to Approach, Help and Treat. Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
 - Invited speaker, Royal College Physicians “Artificial intelligence in gastroenterology  Vision 2020” Royal College of Physician.
 - Invited speaker, King’s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar. “Intelligent physiology: a roadmap to using concurrent physiology as a surgical guide.” 25 March 2021.
 - Invited faculty/chair, London International Upper GI Symposium. Chair, Oesophageal Disorders session. 26 February 2021.

--- a/site_content.md
+++ b/site_content.md
@@ -91,9 +91,7 @@ Zeki SS. EndoMineR for the extraction of endoscopic and associated pathology dat
 
 # Talks
 
-## IBS for General Practice — How to Approach, Help and Treat
-Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
-
+- IBS for General Practice — How to Approach, Help and Treat. Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
 - Invited speaker, Royal College Physicians “Artificial intelligence in gastroenterology  Vision 2020” Royal College of Physician.
 - Invited speaker, King’s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar. “Intelligent physiology: a roadmap to using concurrent physiology as a surgical guide.” 25 March 2021.
 - Invited faculty/chair, London International Upper GI Symposium. Chair, Oesophageal Disorders session. 26 February 2021.


### PR DESCRIPTION
Flattens the elevated "IBS for General Practice" heading into a uniform bullet so every talk in the Talks section renders at the same level, instead of one talk appearing as a large headline above the rest.

Applied to both `content/home/talks.md` (rendered widget) and `site_content.md` (source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd)_