### PR TITLE
Redesign Talks section for a cleaner, more professional look

### DIFF
--- a/content/home/talks.md
+++ b/content/home/talks.md
@@ -15,12 +15,78 @@ subtitle = ""
  css_class = ""
 +++
 
-- IBS for General Practice — How to Approach, Help and Treat. Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
-- Invited speaker, Royal College Physicians “Artificial intelligence in gastroenterology  Vision 2020” Royal College of Physician.
-- Invited speaker, King’s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar. “Intelligent physiology: a roadmap to using concurrent physiology as a surgical guide.” 25 March 2021.
-- Invited faculty/chair, London International Upper GI Symposium. Chair, Oesophageal Disorders session. 26 February 2021.
-- Invited speaker, AImed. “Automation in endoscopy.” Jan 3, 2021.
-- Invited speaker- “How to develop an Endoscopic submucosal dissection service”  2023- St Thomas’ Upper GI Day.
--  Invited speaker, Dr Falk educational meeting. Managing Complications – Eosinophilic oesophagitis Royal College of Physicians in London on Friday 22nd March 2024.
--  Invited keynote speaker, British Society of Gastroenterology Annual Meeting / BSG LIVE’25. “What is the role of Natural Language Processing in Gastroenterology?.” SEC Glasgow, 23–26 June 2025.
--  Invited speaker, British Voice Association Voice Clinics Forum. Topic: laryngopharyngeal reflux / persistent throat symptoms. Guy’s Hospital, London. 6 February 2026. “Reflux and the voice- an evidence based approach”
+<div style="max-width:840px; margin:0 auto;">
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Feb 2026</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Reflux and the Voice — An Evidence-Based Approach</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · British Voice Association Voice Clinics Forum, Guy&rsquo;s Hospital, London</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Jun 2025</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">What Is the Role of Natural Language Processing in Gastroenterology?</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited keynote · British Society of Gastroenterology Annual Meeting (BSG LIVE&rsquo;25), SEC Glasgow</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Mar 2024</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Managing Complications — Eosinophilic Oesophagitis</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · Dr Falk educational meeting, Royal College of Physicians, London</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">2023</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">How to Develop an Endoscopic Submucosal Dissection Service</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · St Thomas&rsquo; Upper GI Day</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Mar 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Intelligent Physiology: A Roadmap to Using Concurrent Physiology as a Surgical Guide</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · King&rsquo;s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Feb 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Oesophageal Disorders <span style="font-weight:400; color:#7a8494;">(session chair)</span></div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited faculty &amp; chair · London International Upper GI Symposium</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Jan 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Automation in Endoscopy</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · AImed</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">2020</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Artificial Intelligence in Gastroenterology — Vision 2020</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · Royal College of Physicians</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Webinar</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">IBS for General Practice — How to Approach, Help and Treat</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients</div>
+    </div>
+  </div>
+
+</div>

--- a/site_content.md
+++ b/site_content.md
@@ -91,15 +91,81 @@ Zeki SS. EndoMineR for the extraction of endoscopic and associated pathology dat
 
 # Talks
 
-- IBS for General Practice — How to Approach, Help and Treat. Webinar covering evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients.
-- Invited speaker, Royal College Physicians “Artificial intelligence in gastroenterology  Vision 2020” Royal College of Physician.
-- Invited speaker, King’s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar. “Intelligent physiology: a roadmap to using concurrent physiology as a surgical guide.” 25 March 2021.
-- Invited faculty/chair, London International Upper GI Symposium. Chair, Oesophageal Disorders session. 26 February 2021.
-- Invited speaker, AImed. “Automation in endoscopy.” Jan 3, 2021.
-- Invited speaker- “How to develop an Endoscopic submucosal dissection service”  2023- St Thomas’ Upper GI Day.
--  Invited speaker, Dr Falk educational meeting. Managing Complications – Eosinophilic oesophagitis Royal College of Physicians in London on Friday 22nd March 2024.
--  Invited keynote speaker, British Society of Gastroenterology Annual Meeting / BSG LIVE’25. “What is the role of Natural Language Processing in Gastroenterology?.” SEC Glasgow, 23–26 June 2025.
--  Invited speaker, British Voice Association Voice Clinics Forum. Topic: laryngopharyngeal reflux / persistent throat symptoms. Guy’s Hospital, London. 6 February 2026. “Reflux and the voice- an evidence based approach”
+<div style="max-width:840px; margin:0 auto;">
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Feb 2026</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Reflux and the Voice — An Evidence-Based Approach</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · British Voice Association Voice Clinics Forum, Guy&rsquo;s Hospital, London</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Jun 2025</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">What Is the Role of Natural Language Processing in Gastroenterology?</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited keynote · British Society of Gastroenterology Annual Meeting (BSG LIVE&rsquo;25), SEC Glasgow</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Mar 2024</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Managing Complications — Eosinophilic Oesophagitis</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · Dr Falk educational meeting, Royal College of Physicians, London</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">2023</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">How to Develop an Endoscopic Submucosal Dissection Service</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · St Thomas&rsquo; Upper GI Day</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Mar 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Intelligent Physiology: A Roadmap to Using Concurrent Physiology as a Surgical Guide</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · King&rsquo;s Health Partners Academic Surgical Grand Round / ALRSG-BI webinar</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Feb 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Oesophageal Disorders <span style="font-weight:400; color:#7a8494;">(session chair)</span></div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited faculty &amp; chair · London International Upper GI Symposium</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Jan 2021</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Automation in Endoscopy</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · AImed</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0; border-bottom:1px solid #e9edf2;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">2020</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">Artificial Intelligence in Gastroenterology — Vision 2020</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Invited speaker · Royal College of Physicians</div>
+    </div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:0.35rem 1.5rem; padding:1.05rem 0;">
+    <div style="flex:0 0 6.5rem; color:#8a94a3; font-size:0.8rem; font-weight:700; letter-spacing:0.05em; text-transform:uppercase; padding-top:0.15rem;">Webinar</div>
+    <div style="flex:1 1 18rem;">
+      <div style="font-weight:600; color:#1a3a5c; font-size:1.05rem; line-height:1.4;">IBS for General Practice — How to Approach, Help and Treat</div>
+      <div style="color:#5a6472; font-size:0.92rem; margin-top:0.25rem;">Evidence-based guidance for IBS diagnosis and treatment, with approaches for empowering patients</div>
+    </div>
+  </div>
+
+</div>
 
 
 # Educational Role


### PR DESCRIPTION
Replaces the plain bullet list in the Talks section with a professional, structured layout:

- **Date-column format** — each talk shows its date in a muted label column beside the detail, the classic CV/talks presentation.
- **Normalized titles** — the actual talk title is surfaced in bold navy (e.g. "What Is the Role of Natural Language Processing in Gastroenterology?"), with the role and venue on a quieter second line.
- **Reverse-chronological order** — most recent first (Feb 2026 → the IBS webinar).
- Uses the site's existing navy (`#1a3a5c`) / grey palette and self-contained inline styles, with responsive `flex-wrap` so it stacks cleanly on mobile.

Edited in `site_content.md` (source of truth); `content/home/talks.md` regenerated via `scripts/build_from_content.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd)_