### PR TITLE
More professional typography and palette

### DIFF
--- a/data/fonts/medical.toml
+++ b/data/fonts/medical.toml
@@ -1,11 +1,11 @@
 # Font metadata
 name = "Medical"
 
-# Serif heading, clean sans body — standard in medical publishing
-heading_font = "Lora"
-body_font    = "Source Sans Pro"
-nav_font     = "Source Sans Pro"
-mono_font    = "Ubuntu Mono"
+# Sharp, journal-grade serif headings + clean modern sans body
+heading_font = "Source Serif 4"
+body_font    = "Inter"
+nav_font     = "Inter"
+mono_font    = "JetBrains Mono"
 
 # Google Fonts URL
-google_fonts = "family=Lora:ital,wght@0,400;0,600;0,700;1,400&family=Source+Sans+Pro:wght@300;400;600;700&family=Ubuntu+Mono&display=swap"
+google_fonts = "family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"

--- a/data/themes/medical.toml
+++ b/data/themes/medical.toml
@@ -5,14 +5,14 @@ name = "Medical"
 light = true
 
 # Deep navy — professional, trustworthy, medical
-primary = "#1a3a5c"
+primary = "#1e3a5f"
 
 # Navbar — dark navy with white text
-menu_primary = "#1a3a5c"
-menu_text = "rgba(255,255,255,0.85)"
+menu_primary = "#1e3a5f"
+menu_text = "rgba(255,255,255,0.82)"
 menu_text_active = "#ffffff"
 menu_title = "#ffffff"
 
-# Alternating sections: crisp white / very light blue-grey
+# Alternating sections: crisp white / very light cool grey
 home_section_odd  = "rgb(255, 255, 255)"
-home_section_even = "rgb(246, 248, 251)"
+home_section_even = "rgb(247, 249, 251)"


### PR DESCRIPTION
Refreshes the site's fonts and colour for a more professional, journal-grade feel:

- **Headings:** Lora → **Source Serif 4** (sharper, more authoritative serif)
- **Body/nav:** Source Sans Pro → **Inter** (cleanest modern professional sans)
- **Mono:** Ubuntu Mono → **JetBrains Mono**
- **Palette:** refined the navy to a slightly richer deep-navy (`#1e3a5f`) with cooler, cleaner alternating section backgrounds

Changes are confined to the theme/font definitions (`data/themes/medical.toml`, `data/fonts/medical.toml`); no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd)_