### PR TITLE
Switch to a clean all-sans look (Inter throughout)

### DIFF
--- a/data/fonts/medical.toml
+++ b/data/fonts/medical.toml
@@ -1,11 +1,11 @@
 # Font metadata
 name = "Medical"
 
-# Sharp, journal-grade serif headings + clean modern sans body
-heading_font = "Source Serif 4"
+# Clean, modern all-sans — Inter throughout, bold headings
+heading_font = "Inter"
 body_font    = "Inter"
 nav_font     = "Inter"
 mono_font    = "JetBrains Mono"
 
 # Google Fonts URL
-google_fonts = "family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+google_fonts = "family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"


### PR DESCRIPTION
Drops serif headings in favour of **Inter for headings, body and nav** — a modern, corporate-professional look and a clearly visible change from the previous serif-headed design. Mono stays JetBrains Mono; the refined deep-navy palette is unchanged.

Single-file change to `data/fonts/medical.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfXzx4LXHdAuA3Z8idBtsd)_